### PR TITLE
Fix threading issues on dialog boxes

### DIFF
--- a/capture.cpp
+++ b/capture.cpp
@@ -1,7 +1,5 @@
 #include <iostream>
 
-#include <QMessageBox>
-
 #include "capture.h"
 
 #include <unistd.h>
@@ -108,8 +106,7 @@ void CaptureThread::run()
 
     ret = ft60x_open(&fd, m_config->device.toUtf8().constData());
     if (ret < 0) {
-        QMessageBox::warning(nullptr, "Error", "Capture device not found");
-
+        emit captureDeviceNotFound();
         return;
     }
     memcpy(&gfd, &fd, sizeof(ftdev_t));
@@ -159,7 +156,7 @@ void CaptureThread::run()
 
         streamid = ubar_recv_packet(fd, &buf, &len);
         if(streamid < 0) {
-            QMessageBox::warning(nullptr, "Error", "Capture device disconnected");
+            emit captureDeviceDisconnected();
             goto exit;
 
         } else if (streamid == 1) {

--- a/capture.h
+++ b/capture.h
@@ -68,6 +68,10 @@ class CaptureThread : public QThread
 
     void run();
 
+signals:
+    void captureDeviceNotFound();
+    void captureDeviceDisconnected();
+
 public:
     void setConfig(CaptureConfig* config);
     void setModel(USBModel *model, MSGModel *msg);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -155,6 +155,8 @@ void MainWindow::startCapture()
         captureThread->setUsbSession(usb_sess);
 
         connect(captureThread, &CaptureThread::finished, this, &MainWindow::captureFinished);
+        connect(captureThread, SIGNAL(captureDeviceNotFound()), this, SLOT(displayDeviceNotFound()), Qt::BlockingQueuedConnection);
+        connect(captureThread, SIGNAL(captureDeviceDisconnected()), this, SLOT(displayDeviceDisconnected()), Qt::BlockingQueuedConnection);
 
         configWindow->autoConfig();
         captureThread->setConfig(&configWindow->m_config);
@@ -312,4 +314,14 @@ void MainWindow::updateDetails(const QModelIndex& index)
 void MainWindow::updateRecordsStats(int number)
 {
     ui->statusPacketNum->setText(QString("Records: %1").arg(number));
+}
+
+void MainWindow::displayDeviceNotFound()
+{
+    QMessageBox::warning(this, "Error", "Capture device not found");
+}
+
+void MainWindow::displayDeviceDisconnected()
+{
+    QMessageBox::warning(this, "Error", "Capture device disconnected");
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -36,6 +36,10 @@ class MainWindow : public QMainWindow
 {
     Q_OBJECT
 
+public slots:
+    void displayDeviceNotFound();
+    void displayDeviceDisconnected();
+
 public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();


### PR DESCRIPTION
On macOS and Windows, all GUI elements are expected to run on the main thread. The CaptureThread creates dialog boxes which run on a separate thread from the MainWindow class, thus creating issues on both platforms.

This commit's approach is to add signals in the CaptureThread class and slots in MainWindow, and move all GUI code out of the CaptureThread class.