### PR TITLE
Improve performance of QTreeView widgets

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -40,6 +40,10 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->statusBar->addPermanentWidget(ui->statusPacketNum);
     ui->mainToolBar->addWidget(ui->statusCapture);
 
+    /* This greatly improves widget drawing perfs when dealing with large datasets */
+    ui->treeView->setUniformRowHeights(true);
+    ui->messageView->setUniformRowHeights(true);
+
     configWindow = new ConfigureWindow(this);
     filterWindow = new FilterWindow(this);
     aboutWindow = new AboutWindow(this);


### PR DESCRIPTION
When displaying lots of items in a QTreeView, it takes a significant amount of time to calculate each item's height. By setting a uniform row height, there is no need to calculate it for each item.