### PR TITLE
Improve performance on "big" files

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -266,7 +266,7 @@ void MainWindow::loadFile()
     }
     usb_sess = usb_new_session();
     newSession();
-
+    
     while(!feof(in)){
         len = fread(swp, 1, 512, in);
         if(len < 0)
@@ -281,9 +281,10 @@ void MainWindow::loadFile()
             currentMsg->addMessage(ts, type, val);
         }
         while(usb_read_packet(usb_sess, &type, buf, &plen, &ts)){
-            currentModel->addPacket(new USBPacket(ts, QByteArray((char *)buf, plen)));
+            currentModel->addPacket(new USBPacket(ts, QByteArray((char *)buf, plen)), false);
         }
     }
+    currentModel->updateNumberPopulated();
 
     currentModel->lastPacket();
     fclose(in);

--- a/usbaggregator.cpp
+++ b/usbaggregator.cpp
@@ -38,6 +38,11 @@ bool USBAggregator::getPending(USBItem **item)
     return true;
 }
 
+int USBAggregator::getPendingCount()
+{
+    return m_pending.size();
+}
+
 void USBAggregator::done()
 {
     endGroup();

--- a/usbaggregator.h
+++ b/usbaggregator.h
@@ -25,6 +25,7 @@ public:
     void done();
     void setRoot(USBItem* root);
     bool getPending(USBItem **item);
+    int getPendingCount();
 
 private:
     USBItem *m_root;

--- a/usbmodel.cpp
+++ b/usbmodel.cpp
@@ -13,14 +13,21 @@ USBModel::~USBModel()
     delete m_rootItem; // FIXME
 }
 
-int USBModel::addPacket(USBPacket *packet)
+int USBModel::addPacket(USBPacket *packet, bool nodeUpdate)
 {
     /* Push packet to aggregator */
     m_aggregator.append(packet);
-    updateNodes();
-    emit numberPopulated(m_aggregator.count());
+    if (nodeUpdate) {
+        updateNodes();
+        emit numberPopulated(m_aggregator.count());
+    }
 
     return true;
+}
+
+void USBModel::updateNumberPopulated()
+{
+    emit numberPopulated(m_aggregator.count());
 }
 
 int USBModel::lastPacket()
@@ -37,14 +44,16 @@ void USBModel::updateNodes()
     USBItem *child;
 
     /* Add new nodes from aggregator, if any */
+    auto pendingCount = m_aggregator.getPendingCount();
+    size = m_rootItem->childCount();
+    beginInsertRows(QModelIndex(), size, size+pendingCount);
 
     while(m_aggregator.getPending(&child))
     {
-        size = m_rootItem->childCount();
-        beginInsertRows(QModelIndex(), size, size);
         m_rootItem->appendChild(child);
-        endInsertRows();
     }
+
+    endInsertRows();
 }
 
 QModelIndex USBModel::index(int row, int column, const QModelIndex &parent)

--- a/usbmodel.h
+++ b/usbmodel.h
@@ -26,10 +26,10 @@ public:
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
     /* custom API */
-    int addPacket(USBPacket *packet);
+    int addPacket(USBPacket *packet, bool nodeUpdate = true);
     int lastPacket();
     void updateNodes();
-
+    void updateNumberPopulated();
 signals:
     void numberPopulated(int number);
 


### PR DESCRIPTION
This PR is focused on improving performance when loading "big" files.

I used Apple's [Instruments.app](https://en.wikipedia.org/wiki/Instruments_(software)) to tell me where we were wasting CPU time. With no changes we had a graph like this :

![Capture d’écran 2019-04-20 à 13 23 49](https://user-images.githubusercontent.com/25333063/56456843-64330e80-6372-11e9-943f-a05d21196a31.png)

*"Spinning" means that the GUI is frozen, in reference to macOS's beach ball icon spinning when the application is unresponsive*

Looking at the profiler output, we can see that most of the time was spent in USBModel::updateNodes().

![Capture d’écran 2019-04-20 à 13 11 52](https://user-images.githubusercontent.com/25333063/56456855-714ffd80-6372-11e9-8cf0-6ed115636b5c.png)

By making fewer calls to this method, I did shave a few seconds off:

![Capture d’écran 2019-04-20 à 13 33 09](https://user-images.githubusercontent.com/25333063/56456868-a2303280-6372-11e9-9add-eb4145b6eb56.png)

By looking at the profiler output even closer, I noticed that we spent too much time in QAbstractItemModel's endInsertRows() method. I decided to make fewer calls to endInsertRows and beginInsertRows() (they go in pairs). That improved a lot the loading times!

![Capture d’écran 2019-04-20 à 13 36 06](https://user-images.githubusercontent.com/25333063/56456878-dc99cf80-6372-11e9-881a-63f09872c9b6.png)

All my tests were performed on this file:
[ft4232trace.usb.zip](https://github.com/lambdaconcept/usb2sniffer-qt/files/3100073/ft4232trace.usb.zip)