### PR TITLE
Fix fread error handling code

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -269,8 +269,9 @@ void MainWindow::loadFile()
     
     while(!feof(in)){
         len = fread(swp, 1, 512, in);
-        if(len < 0)
+        if (ferror(in)) {
             return;
+        }
 
         /* file stored in byte swapped format */
         usb_swap_bytes(buf, swp, len);


### PR DESCRIPTION
In MainWindow::loadFile(), fread error checking code uses a comparison (fread() >= 0) which never works, as fread returns a size_t which is an unsigned value.