### PR TITLE
Fix overflowing text on about window

### DIFF
--- a/aboutwindow.ui
+++ b/aboutwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>559</width>
+    <width>610</width>
     <height>288</height>
    </rect>
   </property>
@@ -16,9 +16,9 @@
   <widget class="QDialogButtonBox" name="buttonBox">
    <property name="geometry">
     <rect>
-     <x>200</x>
-     <y>245</y>
-     <width>341</width>
+     <x>140</x>
+     <y>250</y>
+     <width>461</width>
      <height>32</height>
     </rect>
    </property>
@@ -56,7 +56,7 @@
     <rect>
      <x>140</x>
      <y>10</y>
-     <width>394</width>
+     <width>461</width>
      <height>241</height>
     </rect>
    </property>
@@ -65,6 +65,9 @@
    </property>
    <property name="textFormat">
     <enum>Qt::AutoText</enum>
+   </property>
+   <property name="wordWrap">
+    <bool>true</bool>
    </property>
    <property name="openExternalLinks">
     <bool>true</bool>


### PR DESCRIPTION
Word wrap isn't enabled on the about window's QLabel, therefore the text overflows out of the viewport. I made the widgets big enough to store all the text.