### PR TITLE
Fix empty row when importing USB traces or doing a capture

### DIFF
--- a/usbmodel.cpp
+++ b/usbmodel.cpp
@@ -46,14 +46,17 @@ void USBModel::updateNodes()
     /* Add new nodes from aggregator, if any */
     auto pendingCount = m_aggregator.getPendingCount();
     size = m_rootItem->childCount();
-    beginInsertRows(QModelIndex(), size, size+pendingCount);
 
-    while(m_aggregator.getPending(&child))
-    {
-        m_rootItem->appendChild(child);
+    if (pendingCount > 0) {
+        beginInsertRows(QModelIndex(), size, size+pendingCount-1);
+
+        while(m_aggregator.getPending(&child))
+        {
+            m_rootItem->appendChild(child);
+        }
+
+        endInsertRows();
     }
-
-    endInsertRows();
 }
 
 QModelIndex USBModel::index(int row, int column, const QModelIndex &parent)


### PR DESCRIPTION
There was an issue with beginInsertRows() row indexes, 1 row index was bigger than expected thus creating an empty line which when clicked makes lcsniff crash.

Some infos about this issue here: https://forum.qt.io/topic/28850/qtreeview-with-qsortfilterproxymodel-displays-an-empty-row-after-changing-the-qabstractitemmodel/5