### PR TITLE
Improve filter performance

### DIFF
--- a/usbgroup.cpp
+++ b/usbgroup.cpp
@@ -54,3 +54,8 @@ const QString USBGroup::details()
 
     return details;
 }
+
+quint8 USBGroup::getPid() const
+{
+    return m_first->getPid();
+}

--- a/usbgroup.h
+++ b/usbgroup.h
@@ -12,7 +12,7 @@ public:
     QVariant data(int column) const;
     QBrush background() const;
     const QString details();
-
+	quint8 getPid() const;
 private:
     int m_count;
     USBPacket *m_first;

--- a/usbitem.cpp
+++ b/usbitem.cpp
@@ -99,3 +99,8 @@ const QString USBItem::details()
 {
     return m_record->details();
 }
+
+quint8 USBItem::getPid() const
+{
+    return m_record->getPid();
+}

--- a/usbitem.h
+++ b/usbitem.h
@@ -30,6 +30,7 @@ public:
     const QString asciiData();
     const QString asciiPacket();
     const QString details();
+    quint8 getPid() const;
 
 private:
     QList<USBItem*> m_childItems;

--- a/usbmodel.cpp
+++ b/usbmodel.cpp
@@ -1,6 +1,8 @@
 #include "usbmodel.h"
 #include "usbitem.h"
 
+#include <iostream>
+
 USBModel::USBModel(QObject *parent) : QAbstractItemModel(parent)
 {
     m_rootItem = new USBItem(new USBPacket(0, QByteArray()));
@@ -132,6 +134,16 @@ QVariant USBModel::data(const QModelIndex &index, int role) const
         default:
             return QVariant();
     }
+}
+
+quint8 USBModel::getPid(const QModelIndex &index) const
+{
+    if (!index.isValid())
+        return 0;
+
+    USBItem *item = static_cast<USBItem*>(index.internalPointer());
+
+    return item->getPid();
 }
 
 Qt::ItemFlags USBModel::flags(const QModelIndex &index) const

--- a/usbmodel.h
+++ b/usbmodel.h
@@ -24,6 +24,7 @@ public:
     QModelIndex parent(const QModelIndex &index) const override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+    quint8 getPid(const QModelIndex &index) const;
 
     /* custom API */
     int addPacket(USBPacket *packet, bool nodeUpdate = true);

--- a/usbproxy.cpp
+++ b/usbproxy.cpp
@@ -12,7 +12,7 @@ USBProxy::USBProxy(QObject *parent)
 void USBProxy::setFilter(const USBProxyFilter *filter)
 {
     m_filter = filter;
-    invalidateFilter();
+    invalidate();
 }
 
 bool USBProxy::filterAcceptsRow(int sourceRow,

--- a/usbproxy.cpp
+++ b/usbproxy.cpp
@@ -3,8 +3,6 @@
 #include "usbmodel.h"
 #include "usbproxy.h"
 
-#include <iostream>
-
 USBProxy::USBProxy(QObject *parent)
     : QSortFilterProxyModel (parent)
 {
@@ -20,8 +18,6 @@ void USBProxy::setFilter(const USBProxyFilter *filter)
 bool USBProxy::filterAcceptsRow(int sourceRow,
         const QModelIndex &sourceParent) const
 {
-    std::cout << "handling row " << sourceRow << std::endl;
-
     QModelIndex index = sourceModel()->index(sourceRow, RECORD_NAME, sourceParent);
 
     if (!m_filter) {

--- a/usbproxy.h
+++ b/usbproxy.h
@@ -3,6 +3,7 @@
 
 #include <QString>
 #include <QSortFilterProxyModel>
+#include "usbmodel.h"
 
 class USBProxyFilter
 {
@@ -26,6 +27,7 @@ public:
 
 protected:
     bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
+    USBModel* usbModel() const;
 
 private:
     const USBProxyFilter *m_filter = nullptr;

--- a/usbrecord.h
+++ b/usbrecord.h
@@ -29,6 +29,7 @@ public:
     virtual const QString asciiData();
     virtual const QString asciiPacket();
     virtual const QString details();
+    virtual quint8 getPid() const = 0;
 };
 
 #endif // USBRECORD_H

--- a/usbtransaction.cpp
+++ b/usbtransaction.cpp
@@ -94,3 +94,8 @@ const QString USBTransaction::details()
 
     return details;
 }
+
+quint8 USBTransaction::getPid() const
+{
+    return m_token->getPid();
+}

--- a/usbtransaction.h
+++ b/usbtransaction.h
@@ -14,6 +14,7 @@ public:
     QFont font(int column) const;
     const QString asciiData();
     const QString details();
+    quint8 getPid() const;
 
 private:
     USBPacket* m_token;


### PR DESCRIPTION
Hi!

This PR includes the following changes:
 * Propagation of `getPid()` data from the USBRecord classes down to the model (so that we have less string comparisons to do)
 * Replacement of `invalidateFilter()` with `invalidate()` in USBProxy which to my amazement greatly improved performance. From my understanding, `invalidate()` doesn't bother with sorting whereas `invalidateFiler()` does.