### PR TITLE
Hex editor view

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "qhexedit2"]
+	path = qhexedit2
+	url = https://github.com/Simsys/qhexedit2

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Open lcsniff.pro with Qt Creator
 ### Linux
 
 ```
+git submodule init
+git submodule update
 mkdir build
 cd build
 qmake ../lcsniff.pro
@@ -22,6 +24,8 @@ make -j
 ### macOS
 
 ```
+git submodule init
+git submodule update
 brew install qt
 mkdir build
 cd build

--- a/lcsniff.pro
+++ b/lcsniff.pro
@@ -25,8 +25,11 @@ DEFINES += QT_DEPRECATED_WARNINGS
 CONFIG += c++11
 
 SOURCES += \
-        main.cpp \
-        mainwindow.cpp \
+    main.cpp \
+    qhexedit2/src/chunks.cpp \
+    qhexedit2/src/commands.cpp \
+    qhexedit2/src/qhexedit.cpp \
+    mainwindow.cpp \
     usbitem.cpp \
     usbmodel.cpp \
     usbpacket.cpp \
@@ -48,7 +51,10 @@ SOURCES += \
     aboutwindow.cpp
 
 HEADERS += \
-        mainwindow.h \
+    qhexedit2/src/commands.h \
+    qhexedit2/src/chunks.h \
+    qhexedit2/src/qhexedit.h \
+    mainwindow.h \
     usbitem.h \
     usbmodel.h \
     usbpacket.h \
@@ -96,6 +102,7 @@ mac {
 }
 
 INCLUDEPATH += $$PWD/xbar/ft60x/FTD3XXLibrary/Win32
+INCLUDEPATH += $$PWD/qhexedit2/src
 DEPENDPATH += $$PWD/xbar/ft60x/FTD3XXLibrary/Win32
 
 win32:!win32-g++: PRE_TARGETDEPS += $$PWD/xbar/ft60x/FTD3XXLibrary/Win32/FTD3XX.lib

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -62,6 +62,11 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(filterWindow, &FilterWindow::accepted, this, &MainWindow::setFilter);
 
     connect(ui->actionAbout, &QAction::triggered, aboutWindow, &AboutWindow::open);
+
+    ui->textAsciiPacket->setReadOnly(true);
+    ui->textAsciiPacket->setDynamicBytesPerLine(true);
+    ui->textAsciiData->setReadOnly(true);
+    ui->textAsciiData->setDynamicBytesPerLine(true);
 }
 
 MainWindow::~MainWindow()
@@ -301,8 +306,11 @@ void MainWindow::updateAscii(const QModelIndex& index)
     QModelIndex source = currentProxy->mapToSource(index);
     USBItem *item = static_cast<USBItem*>(source.internalPointer());
 
-    ui->textAsciiPacket->setPlainText(item->asciiPacket());
-    ui->textAsciiData->setPlainText(item->asciiData());
+    auto recordData = item->recordData();
+    dataBuffer = recordData.first;
+    packetBuffer = recordData.second;
+    ui->textAsciiPacket->setData(packetBuffer);
+    ui->textAsciiData->setData(dataBuffer);
 }
 
 void MainWindow::updateDetails(const QModelIndex& index)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -74,6 +74,9 @@ private:
     bool fileSaved = true; /* Used for warning on exit */
 
     struct usb_session_s *usb_sess = nullptr;
+
+    QByteArray dataBuffer;
+    QByteArray packetBuffer;
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -134,20 +134,12 @@
             </attribute>
             <layout class="QGridLayout" name="gridLayout_3">
              <item row="0" column="0">
-              <widget class="QTextEdit" name="textAsciiPacket">
+              <widget class="QHexEdit" name="textAsciiPacket">
                <property name="minimumSize">
                 <size>
                  <width>0</width>
                  <height>0</height>
                 </size>
-               </property>
-               <property name="font">
-                <font>
-                 <family>Monospace</family>
-                </font>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -159,20 +151,12 @@
             </attribute>
             <layout class="QGridLayout" name="gridLayout_2">
              <item row="0" column="0">
-              <widget class="QTextEdit" name="textAsciiData">
+              <widget class="QHexEdit" name="textAsciiData">
                <property name="minimumSize">
                 <size>
                  <width>0</width>
                  <height>0</height>
                 </size>
-               </property>
-               <property name="font">
-                <font>
-                 <family>Monospace</family>
-                </font>
-               </property>
-               <property name="readOnly">
-                <bool>true</bool>
                </property>
               </widget>
              </item>

--- a/usbitem.cpp
+++ b/usbitem.cpp
@@ -104,3 +104,7 @@ quint8 USBItem::getPid() const
 {
     return m_record->getPid();
 }
+
+QPair<QByteArray, QByteArray> USBItem::recordData() {
+    return m_record->recordData();
+}

--- a/usbitem.h
+++ b/usbitem.h
@@ -31,6 +31,7 @@ public:
     const QString asciiPacket();
     const QString details();
     quint8 getPid() const;
+    QPair<QByteArray, QByteArray> recordData();
 
 private:
     QList<USBItem*> m_childItems;

--- a/usbpacket.cpp
+++ b/usbpacket.cpp
@@ -175,3 +175,8 @@ const QString USBPacket::details()
 
     return details;
 }
+
+QPair<QByteArray, QByteArray> USBPacket::recordData()
+{
+    return qMakePair(m_Data, m_Packet);
+}

--- a/usbpacket.h
+++ b/usbpacket.h
@@ -49,6 +49,7 @@ public:
     const QString asciiData();
     const QString asciiPacket();
     const QString details();
+    QPair<QByteArray, QByteArray> recordData();
 
 public:
     quint64 m_Timestamp;

--- a/usbrecord.cpp
+++ b/usbrecord.cpp
@@ -44,3 +44,8 @@ const QString USBRecord::details()
 {
     return QString();
 }
+
+QPair<QByteArray, QByteArray> USBRecord::recordData()
+{
+    return qMakePair(emptyByteArray, emptyByteArray);
+}

--- a/usbrecord.h
+++ b/usbrecord.h
@@ -30,6 +30,9 @@ public:
     virtual const QString asciiPacket();
     virtual const QString details();
     virtual quint8 getPid() const = 0;
+    virtual QPair<QByteArray, QByteArray> recordData();
+private:
+    const QByteArray emptyByteArray;
 };
 
 #endif // USBRECORD_H

--- a/usbtransaction.cpp
+++ b/usbtransaction.cpp
@@ -101,3 +101,12 @@ quint8 USBTransaction::getPid() const
 {
     return m_token->getPid();
 }
+
+QPair<QByteArray, QByteArray> USBTransaction::recordData()
+{
+    if (m_data) {
+        return qMakePair(m_data->m_Data, emptyBuffer);
+    } else {
+        return qMakePair(emptyBuffer, emptyBuffer);
+    }
+}

--- a/usbtransaction.h
+++ b/usbtransaction.h
@@ -15,11 +15,13 @@ public:
     const QString asciiData();
     const QString details();
     quint8 getPid() const;
+    QPair<QByteArray, QByteArray> recordData();
 
 private:
     USBPacket* m_token;
     USBPacket* m_data;
     USBPacket* m_handshake;
+    QByteArray emptyBuffer;
 };
 
 #endif // USBTRANSACTION_H


### PR DESCRIPTION
In this pull request I replaced the old textview-based hexadecimal inspector, and replaced it with the QHexEdit widget from https://github.com/Simsys/qhexedit2

It resizes correctly, copy/paste works OK on hexadecimal even if hex breaks on a new line however you can't copy/paste ASCII caracters.

![Capture d’écran 2019-05-30 à 15 46 05](https://user-images.githubusercontent.com/25333063/58637211-50c07f00-82f2-11e9-9fe0-3e76f7fbeb14.png)
![Capture d’écran 2019-05-30 à 15 46 19](https://user-images.githubusercontent.com/25333063/58637214-528a4280-82f2-11e9-9174-8186c21ab7c0.png)

Tested OK on macOS & GNOME on Linux.