### PR TITLE
Hide useless settings for macOS & Windows platform

### DIFF
--- a/configurewindow.cpp
+++ b/configurewindow.cpp
@@ -40,15 +40,18 @@ void ConfigureWindow::open()
 
     /* Refresh devices list */
 
+    #if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
+    ui->comboDevice->hide();
+    ui->captureDeviceLabel->hide();
+    #else
     ui->comboDevice->clear();
     QStringList devices = listAvailableDevices();
     ui->comboDevice->addItems(devices);
-
     /* Restore last device selection if still available */
-
     if (devices.contains(current)) {
         ui->comboDevice->setCurrentText(current);
     }
+    #endif
 
     index = ui->comboSpeed->findData(m_config.speed);
     ui->comboSpeed->setCurrentIndex(index);

--- a/configurewindow.ui
+++ b/configurewindow.ui
@@ -23,7 +23,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="captureDeviceLabel">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
          <horstretch>0</horstretch>


### PR DESCRIPTION
macOS & Windows users aren't concerned with /dev/ device selection, this PR hides this setting for the users of those operating systems.