### PR TITLE
Buffer USB messages before storing them into MSGModel

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -274,7 +274,7 @@ void MainWindow::loadFile()
     }
     usb_sess = usb_new_session();
     newSession();
-    
+
     while(!feof(in)){
         len = fread(swp, 1, 512, in);
         if (ferror(in)) {
@@ -286,9 +286,12 @@ void MainWindow::loadFile()
 
         usb_add_data(usb_sess, buf, len);
 
+        std::vector<std::tuple<uint64_t, uint8_t, uint8_t>> msgVec;
         while(usb_read_data(usb_sess, &type, &val, &ts)){
-            currentMsg->addMessage(ts, type, val);
+            msgVec.push_back(std::make_tuple(ts, type, val));
         }
+        currentMsg->addMessageVector(msgVec);
+
         while(usb_read_packet(usb_sess, &type, buf, &plen, &ts)){
             currentModel->addPacket(new USBPacket(ts, QByteArray((char *)buf, plen)), false);
         }

--- a/src/msgmodel.cpp
+++ b/src/msgmodel.cpp
@@ -13,12 +13,25 @@ MSGModel::~MSGModel()
 
 int MSGModel::addMessage(uint64_t ts, uint8_t type, uint8_t val)
 {
-    int size;
-
-    size = m_rootItem->childCount();
+    int size = m_rootItem->childCount();
     beginInsertRows(QModelIndex(), size, size);
     m_rootItem->appendChild(new MSGItem(ts, type, val, m_rootItem));
     endInsertRows();
+
+    return true;
+}
+
+int MSGModel::addMessageVector(std::vector<std::tuple<uint64_t, uint8_t, uint8_t>>& vec)
+{
+    if (vec.size() > 0) {
+        int size = m_rootItem->childCount();
+
+        beginInsertRows(QModelIndex(), size, size+vec.size()-1);
+        for (auto&& message: vec) {
+            m_rootItem->appendChild(new MSGItem(std::get<0>(message), std::get<1>(message), std::get<2>(message), m_rootItem));
+        }
+        endInsertRows();
+    }
 
     return true;
 }

--- a/src/msgmodel.h
+++ b/src/msgmodel.h
@@ -25,6 +25,7 @@ public:
 
     /* custom API */
     int addMessage(uint64_t ts, uint8_t type, uint8_t val);
+    int addMessageVector(std::vector<std::tuple<uint64_t, uint8_t, uint8_t>>& vec);
 
 private:
     MSGItem *m_rootItem;


### PR DESCRIPTION
This patchy fix improves file loading speeds. It buffers USB messages into an std::vector before sending them to MSGModel (because appending to a QAbstractItemModel takes a while).

Before:
![Capture d’écran 2019-10-16 à 21 45 09](https://user-images.githubusercontent.com/25333063/66954265-57ad1b80-f060-11e9-8557-12360696c2ea.png)

After:
![Capture d’écran 2019-10-16 à 21 51 43](https://user-images.githubusercontent.com/25333063/66954277-5ed42980-f060-11e9-8a3d-e9d3e035f5ea.png)

