### PR TITLE
Increase buffer size in loadFile()

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -252,8 +252,8 @@ void MainWindow::loadFile()
     FILE *in;
     size_t len;
     uint32_t plen;
-    uint8_t buf[512];
-    uint8_t swp[512];
+    uint8_t buf[1024];
+    uint8_t swp[1024];
     uint8_t type;
     uint8_t val;
     uint64_t ts;


### PR DESCRIPTION
USB 3.0 allows for BULK transactions above 512b (up to 1024b). In the loadFile() function we used 512b buffers which caused stack overflows.

This commit fixes #16.