### PR TITLE
File association on macOS

### DIFF
--- a/lcsniff.plist
+++ b/lcsniff.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>lcsniff</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>com.lambdaconcept.lcsniff</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.12</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+	<key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>usb</string>
+            </array>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/lcsniff.pro
+++ b/lcsniff.pro
@@ -48,7 +48,8 @@ SOURCES += \
     src/msgmodel.cpp \
     parser/parse.c \
     xbar/ft60x/fops.c \
-    src/aboutwindow.cpp
+    src/aboutwindow.cpp \
+    src/lcsniffapplication.cpp
 
 HEADERS += \
     qhexedit2/src/commands.h \
@@ -76,7 +77,8 @@ HEADERS += \
     src/msgmodel.h \
     parser/parse.h \
     xbar/ft60x/fops.h \
-    src/aboutwindow.h
+    src/aboutwindow.h \
+    src/lcsniffapplication.h
 
 FORMS += \
     ui/mainwindow.ui \
@@ -99,6 +101,7 @@ mac {
     Resources.files += $$PWD/xbar/ft60x/FTD3XXLibrary/macOS/libftd3xx.dylib
     Resources.path = Contents/MacOS
     QMAKE_BUNDLE_DATA += Resources
+    QMAKE_INFO_PLIST = $$PWD/lcsniff.plist
 }
 
 INCLUDEPATH += $$PWD/xbar/ft60x/FTD3XXLibrary/Win32

--- a/src/lcsniffapplication.cpp
+++ b/src/lcsniffapplication.cpp
@@ -1,0 +1,17 @@
+#include "lcsniffapplication.h"
+
+LCSniffApplication::LCSniffApplication(int &argc, char **argv) : QApplication(argc, argv)
+{
+
+}
+
+bool LCSniffApplication::event(QEvent *event)
+{
+	if (event->type() == QEvent::FileOpen) {
+		QFileOpenEvent *openEvent = static_cast<QFileOpenEvent *>(event);
+		qDebug() << "Open file" << openEvent->file();
+		emit fileEvent(openEvent->file());
+	}
+
+	return QApplication::event(event);
+}

--- a/src/lcsniffapplication.h
+++ b/src/lcsniffapplication.h
@@ -1,0 +1,19 @@
+#ifndef LCSNIFFAPPLICATION_H
+#define LCSNIFFAPPLICATION_H
+
+#include <QApplication>
+#include <QFileOpenEvent>
+#include <QtDebug>
+
+class LCSniffApplication : public QApplication
+{
+	Q_OBJECT
+
+signals:
+    void fileEvent(QString file);
+public:
+    LCSniffApplication(int &argc, char **argv);
+    bool event(QEvent *event);
+};
+
+#endif /* LCSNIFFAPPLICATION_H */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,13 @@
+#include "lcsniffapplication.h"
 #include "mainwindow.h"
-#include <QApplication>
 
 int main(int argc, char *argv[])
 {
-    QApplication a(argc, argv);
-    MainWindow w;
-    w.showMaximized();
+    LCSniffApplication app(argc, argv);
+    MainWindow win;
 
-    return a.exec();
+    QObject::connect(&app, SIGNAL(fileEvent(QString)), &win, SLOT(loadFile(QString)));
+    win.showMaximized();
+
+    return app.exec();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -52,9 +52,7 @@ MainWindow::MainWindow(QWidget *parent) :
     filterWindow = new FilterWindow(this);
     aboutWindow = new AboutWindow(this);
 
-    // loadFile(); // FIXME for dev
-
-    connect(ui->actionOpen, &QAction::triggered, this, &MainWindow::loadFile);
+    connect(ui->actionOpen, &QAction::triggered, this, &MainWindow::loadFileDialog);
     connect(ui->actionSave_As, &QAction::triggered, this, &MainWindow::saveFile);
     connect(ui->actionExit, &QAction::triggered, this, &MainWindow::exit);
 
@@ -248,7 +246,14 @@ void MainWindow::saveFile()
     fileSaved = true;
 }
 
-void MainWindow::loadFile()
+void MainWindow::loadFileDialog()
+{
+    QString file = QFileDialog::getOpenFileName(this,
+        "Open File", "", "*.usb");
+    loadFile(file);
+}
+
+void MainWindow::loadFile(QString file)
 {
     FILE *in;
     size_t len;
@@ -258,9 +263,6 @@ void MainWindow::loadFile()
     uint8_t type;
     uint8_t val;
     uint64_t ts;
-
-    QString file = QFileDialog::getOpenFileName(this,
-        "Open File", "", "*.usb");
 
     in = fopen(file.toUtf8().constData(), "rb");
     if(!in) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -40,12 +40,13 @@ public slots:
     void displayDeviceNotFound();
     void displayDeviceDisconnected();
     void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
+    void loadFile(QString file);
 
 public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
-    void loadFile();
+    void loadFileDialog();
     void saveFile();
     void exit();
 


### PR DESCRIPTION
This commit brings file association features on macOS (file open event handling, correct PLIST file): there's no need anymore to use the "open file" dialog to open a file, you can simply double-click on a *.usb file or drag'n'drop it to the LCSniff app icon.