### PR TITLE
Add high level capture option (disabling messages)

### DIFF
--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -163,7 +163,7 @@ void CaptureThread::run()
             usb_add_data(m_sess, (uint8_t*)buf, len);
 
             while(usb_read_data(m_sess, &type, &val, &ts)) {
-                if (start_event) {
+                if (start_event && !m_config->enableHighLevelMode) {
                     messageBuffer.push_back(std::make_tuple(ts, type, val));
                 }
             }

--- a/src/capture.h
+++ b/src/capture.h
@@ -56,6 +56,7 @@ class CaptureConfig
 public:
     QString device;
     int speed = 0;
+    bool enableHighLevelMode = false;
 
     static const QVector<QString> s_speedStr;
 

--- a/src/configurewindow.cpp
+++ b/src/configurewindow.cpp
@@ -62,6 +62,7 @@ void ConfigureWindow::accept()
 
     m_config.device = ui->comboDevice->currentText();
     m_config.speed = ui->comboSpeed->currentData().toInt();
+    m_config.enableHighLevelMode = ui->enableHighLevelMode->checkState() == Qt::Checked;
 
     QDialog::accept();
 }

--- a/ui/configurewindow.ui
+++ b/ui/configurewindow.ui
@@ -68,6 +68,26 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QLabel" name="labelHighLevelMode">
+       <property name="text">
+        <string>High level capture (message recording disabled)</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="enableHighLevelMode"/>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
![Capture d’écran de 2019-10-30 19-50-26](https://user-images.githubusercontent.com/25333063/67890191-88a54a00-fb50-11e9-9dab-9dd11da9c743.png)

When doing protocol analysis USB messages are rarely used and therefore their recording can be disabled.