### PR TITLE
Fix build failure due to missing QKeyEvent header

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,5 +1,6 @@
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QKeyEvent>
 
 #include "pcapexport.h"
 #include "mainwindow.h"


### PR DESCRIPTION
Build failed with `invalid static_cast from type ‘QEvent*’ to type ‘QKeyEvent*’`
in [`src/mainwindow.cpp:429`](https://github.com/lambdaconcept/usb2sniffer-qt/blob/e5eb82cb8599632d4c7b9de1dfaaad67e69ddafa/src/mainwindow.cpp#L429), including the header fixes that.